### PR TITLE
Update requirements.txt for pydantic fix (langchain report)

### DIFF
--- a/gpt_migrate/requirements.txt
+++ b/gpt_migrate/requirements.txt
@@ -4,3 +4,4 @@ yaspin
 openai
 tree_sitter
 litellm==0.1.213
+pydantic==1.10.8


### PR DESCRIPTION
based on this bug report https://github.com/langchain-ai/langchain/issues/8158, we have to pin the version of pydantic. 
if not, it continuously gives the following error

```
user@Arrakis:~/Code/arakoo/gpt-migrate/gpt_migrate$ python main.py --targetlang nodejs --sourcedir /home/user/Code/arakoo/EdgeChains/FlySpring/  --targetdir java
Traceback (most recent call last):
  File "/home/user/Code/arakoo/gpt-migrate/gpt_migrate/main.py", line 7, in <module>
    from ai import AI
  File "/home/user/Code/arakoo/gpt-migrate/gpt_migrate/ai.py", line 1, in <module>
    from langchain.chat_models import ChatOpenAI
  File "/home/user/Code/miniconda3/lib/python3.10/site-packages/langchain/__init__.py", line 6, in <module>
    from langchain.agents import MRKLChain, ReActChain, SelfAskWithSearchChain
  File "/home/user/Code/miniconda3/lib/python3.10/site-packages/langchain/agents/__init__.py", line 40, in <module>
    from langchain.agents.agent_toolkits import (
  File "/home/user/Code/miniconda3/lib/python3.10/site-packages/langchain/agents/agent_toolkits/__init__.py", line 13, in <module>
    from langchain.agents.agent_toolkits.csv.base import create_csv_agent
  File "/home/user/Code/miniconda3/lib/python3.10/site-packages/langchain/agents/agent_toolkits/csv/base.py", line 4, in <module>
    from langchain.agents.agent_toolkits.pandas.base import create_pandas_dataframe_agent
  File "/home/user/Code/miniconda3/lib/python3.10/site-packages/langchain/agents/agent_toolkits/pandas/base.py", line 18, in <module>
    from langchain.agents.types import AgentType
  File "/home/user/Code/miniconda3/lib/python3.10/site-packages/langchain/agents/types.py", line 5, in <module>
    from langchain.agents.chat.base import ChatAgent
  File "/home/user/Code/miniconda3/lib/python3.10/site-packages/langchain/agents/chat/base.py", line 4, in <module>
    from langchain.agents.chat.output_parser import ChatOutputParser
  File "/home/user/Code/miniconda3/lib/python3.10/site-packages/langchain/agents/chat/output_parser.py", line 12, in <module>
    class ChatOutputParser(AgentOutputParser):
  File "pydantic/main.py", line 229, in pydantic.main.ModelMetaclass.__new__
  File "pydantic/fields.py", line 491, in pydantic.fields.ModelField.infer
  File "pydantic/fields.py", line 421, in pydantic.fields.ModelField.__init__
  File "pydantic/fields.py", line 542, in pydantic.fields.ModelField.prepare
  File "pydantic/fields.py", line 804, in pydantic.fields.ModelField.populate_validators
  File "pydantic/validators.py", line 723, in find_validators
RuntimeError: no validator found for <class 're.Pattern'>, see `arbitrary_types_allowed` in Config
```